### PR TITLE
【提出】商品詳細表示機能

### DIFF
--- a/app/controllers/buy_items_controller.rb
+++ b/app/controllers/buy_items_controller.rb
@@ -2,7 +2,7 @@ class BuyItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
 
   def index
-    @buy_items = BuyItem.all
+    @buy_items = BuyItem.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/buy_items_controller.rb
+++ b/app/controllers/buy_items_controller.rb
@@ -25,7 +25,7 @@ class BuyItemsController < ApplicationController
   private
 
   def buy_item_params
-    params.require(:buy_item).permit(:title, :content, :category_id, :item_status_id, :shipping_days_id, :shipping_fee_id, :shipping_orig_id, :price, :image).merge(user_id: current_user.id)
+    params.require(:buy_item).permit(:title, :content, :category_id, :item_status_id, :shipping_day_id, :shipping_fee_id, :shipping_orig_id, :price, :image).merge(user_id: current_user.id)
   end
 
   def move_to_index

--- a/app/controllers/buy_items_controller.rb
+++ b/app/controllers/buy_items_controller.rb
@@ -1,5 +1,5 @@
 class BuyItemsController < ApplicationController
-  before_action :move_to_index, except: [:index]
+  before_action :move_to_index, except: [:index, :show]
 
   def index
     @buy_items = BuyItem.all
@@ -7,6 +7,10 @@ class BuyItemsController < ApplicationController
 
   def new
     @buy_item = BuyItem.new
+  end
+
+  def show
+    @buy_item = BuyItem.find(params[:id])
   end
 
   def create
@@ -17,6 +21,7 @@ class BuyItemsController < ApplicationController
       render :new
     end
   end
+
 
   private
 

--- a/app/controllers/buy_items_controller.rb
+++ b/app/controllers/buy_items_controller.rb
@@ -2,7 +2,7 @@ class BuyItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
 
   def index
-    @buy_items = BuyItem.all.order("created_at DESC")
+    @buy_items = BuyItem.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/buy_items_controller.rb
+++ b/app/controllers/buy_items_controller.rb
@@ -22,7 +22,6 @@ class BuyItemsController < ApplicationController
     end
   end
 
-
   private
 
   def buy_item_params

--- a/app/models/buy_item.rb
+++ b/app/models/buy_item.rb
@@ -16,7 +16,7 @@ class BuyItem < ApplicationRecord
     validates :image
     validates :category_id,      numericality: { other_than: 1 }
     validates :item_status_id,   numericality: { other_than: 1 }
-    validates :shipping_days_id, numericality: { other_than: 1 }
+    validates :shipping_day_id, numericality: { other_than: 1 }
     validates :shipping_fee_id,  numericality: { other_than: 1 }
     validates :shipping_orig_id, numericality: { other_than: 1 }
     validates_inclusion_of :price, in: 300..9_999_999, message: 'out of range'

--- a/app/views/buy_items/_notlogin.html.erb
+++ b/app/views/buy_items/_notlogin.html.erb
@@ -1,42 +1,4 @@
-<%= render "shared/header" %>
 
-<%# 商品の概要 %>
-<div class="item-show">
-  <div class="item-box">
-    <h2 class="name">
-      <%= @buy_item.title %>
-    </h2>
-    <div class='item-img-content'>
-      <%= image_tag @buy_item.image.variant(resize:'504x500'), class: 'item-box-img' if @buy_item.image.attached?%>
-      <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
-    </div>
-    <div class="item-price-box">
-      <span class="item-price">
-      <%= @buy_item.price %>円
-      </span>
-      <span class="item-postage">
-        (税込) 送料込み
-      </span>
-    </div>
-
-    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-  <% if user_signed_in? && current_user.id == @buy_item.user_id %>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-  <% elsif user_signed_in? && current_user.id != @buy_item.user_id %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-  <% else %>
-    <%= render "notlogin" %>
-  <% end %>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/buy_items/index.html.erb
+++ b/app/views/buy_items/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
     <% @buy_items.each do |buy_item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to buy_item_path(buy_item.id) do%>
         <div class='item-img-content'>
           <div>
             <%= image_tag buy_item.image.variant(resize:'281x281'), class: 'item-img' if buy_item.image.attached?%>
@@ -141,6 +141,7 @@
           <%# //商品が売れていればsold outの表示 %>
 
         </div>
+        <% end%>
         <div class='item-info'>
           <h3 class='item-name'>
             <%= buy_item.title %>
@@ -153,7 +154,6 @@
             </div>
           </div>
         </div>
-          <% end %>
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>

--- a/app/views/buy_items/new.html.erb
+++ b/app/views/buy_items/new.html.erb
@@ -79,7 +79,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_days_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/buy_items/show.html.erb
+++ b/app/views/buy_items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @buy_item.title %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @buy_item.image.variant(resize:'504x500'), class: 'item-box-img' if @buy_item.image.attached?%>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+      <%= @buy_item.price %>円
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -42,27 +42,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @buy_item.user.name%></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @buy_item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @buy_item.item_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @buy_item.shipping_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @buy_item.shipping_orig.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @buy_item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/db/migrate/20200829034802_create_buy_items.rb
+++ b/db/migrate/20200829034802_create_buy_items.rb
@@ -7,7 +7,7 @@ class CreateBuyItems < ActiveRecord::Migration[6.0]
       t.integer          :item_status_id,      null:false
       t.integer          :shipping_fee_id,     null:false
       t.integer          :shipping_orig_id,    null:false
-      t.integer          :shipping_days_id,    null:false
+      t.integer          :shipping_day_id,     null:false
       t.integer          :price,               null:false
       t.integer          :user_id,             null:false, foreign_key: true
       t.timestamps

--- a/db/migrate/20200901080417_rename_shipping_days_id_column_to_shipping_days.rb
+++ b/db/migrate/20200901080417_rename_shipping_days_id_column_to_shipping_days.rb
@@ -1,0 +1,5 @@
+class RenameShippingDaysIdColumnToShippingDays < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :buy_items, :shipping_days_id, :shipping_day_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_31_052517) do
+ActiveRecord::Schema.define(version: 2020_09_01_080417) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_052517) do
     t.integer "item_status_id", null: false
     t.integer "shipping_fee_id", null: false
     t.integer "shipping_orig_id", null: false
-    t.integer "shipping_days_id", null: false
+    t.integer "shipping_day_id", null: false
     t.integer "price", null: false
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/buy_items.rb
+++ b/spec/factories/buy_items.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     content           { Faker::Lorem.sentence }
     category_id       { Faker::Number.within(range: 2..11) }
     item_status_id    { Faker::Number.within(range: 2..7) }
-    shipping_days_id  { Faker::Number.within(range: 2..3) }
+    shipping_day_id   { Faker::Number.within(range: 2..4) }
     shipping_fee_id   { Faker::Number.within(range: 2..4) }
     shipping_orig_id  { Faker::Number.within(range: 2..5) }
     price             { Faker::Number.within(range: 300..9_999_999) }

--- a/spec/models/buy_item_spec.rb
+++ b/spec/models/buy_item_spec.rb
@@ -58,13 +58,13 @@ RSpec.describe BuyItem, type: :model do
     end
 
     it '発送までの日数が空だと登録できない' do
-      @buy_item.shipping_days_id = '1'
+      @buy_item.shipping_day_id = '1'
       @buy_item.valid?
-      expect(@buy_item.errors.full_messages).to include('Shipping days must be other than 1')
+      expect(@buy_item.errors.full_messages).to include('Shipping day must be other than 1')
     end
 
     it '価格が空だと登録できない' do
-      @buy_item.price = '0'
+      @buy_item.price = ''
       @buy_item.valid?
       expect(@buy_item.errors.full_messages).to include('Price out of range')
     end


### PR DESCRIPTION

 1.what
—————————————
❶ログインかつ出品者/ログインかつ出品者じゃない/ログアウトしている状態の３パターンで商品詳細表示ページ分岐。
❷商品詳細時に登録した情報表示。
❸Robocopにて文字修正。

2.why
—————————————
❶不正を起こさないため。
❷商品の詳細を見れるようにしないと商品情報がなく、購入にいたらないため。
❸可読性をあげるため。

3.動作確認
—————————————
❶ログインかつ出品者の商品詳細ページ
https://gyazo.com/b30d71e31b25d6a9cddd5ae8c12ad42f

❷ログインかつ出品者じゃない商品詳細ページ
https://gyazo.com/5c6b723ac39aa60b30fe09937e8ae059

❸ログアウト時の商品詳細ページ
https://gyazo.com/cc44f26632bee1ea1d790fb6a65eb342

4.注意事項
—————————————
別タスク：【商品一覧表示機能】タスクの『売却済みの商品は、「sold out」の文字が表示されるようになっていること』については【商品購入機能】タスクで購入者IDでtrue falseで判定しないといけないと判断し、【商品一覧表示機能】タスクはPRしていません。先に【商品詳細表示機能】を実装しています。